### PR TITLE
Exclude cost-management permissions from rbac for role creation

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -33,6 +33,20 @@ deploy() {
   -p rbac/REPLICATION_TO_RELATION_ENABLED=True -p rbac/BYPASS_BOP_VERIFICATION=True \
   -p rbac/KAFKA_ENABLED=False -p rbac/NOTIFICATONS_ENABLED=False \
   -p rbac/NOTIFICATIONS_RH_ENABLED=False \
+ -p rbac/ROLE_CREATE_ALLOW_LIST="remediations,\
+inventory,\
+policies,\
+advisor,\
+vulnerability,\
+compliance,\
+automation-analytics,\
+notifications,\
+patch,\
+integrations,\
+ros,\
+staleness,\
+config-manager,\
+idmsvc" \
   --set-image-tag quay.io/cloudservices/insights-inventory=latest \
   --set-image-tag quay.io/cloudservices/insights-inventory-frontend="${HOST_FRONTEND_GIT_COMMIT}" \
   --set-image-tag quay.io/redhat-services-prod/hcc-platex-services/chrome-service=latest \


### PR DESCRIPTION
Default value of ROLE_CREATE_ALLOW_LIST  variable contained also `cost-management` permission: 
```
 -p rbac/ROLE_CREATE_ALLOW_LIST="remediations,\
 inventory,\
 policies,\
 advisor,\
 vulnerability,\
 compliance,\
 automation-analytics,\
 notifications,\
 patch,\
 integrations,\
 ros,\
 staleness,\
 config-manager,\
 idmsvc" \
```

but this permission caused issue in role creation wizard in UI, more info https://issues.redhat.com/browse/RHCLOUD-39735