### PR TITLE
RHCLOUD-40053: Add unleash automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,37 +27,40 @@ access managed with rbac and queried with kessel.
 (We are in the process of automating the below steps.)
 
 1. Ensure the deploy.sh script has run correctly, above.
-2. Set `hbi.api.kessel-workspace-migration` feature flag in unleash:
-```shell
-# Change service to correct namespace
-oc port-forward svc/env-ephemeral-ipnfoy-featureflags 4242
-```
-```shell
-Log in to Unleash at `localhost:4242` with the creds:
-
-  -   user: admin
-  -   pass: unleash4all
-Create the `hbi.api.kessel-workspace-migration` in Unleash and turn it on, and then you can cancel out of the port-forward command.
-```
-3. Create test hosts in HBI:
+2. Create test hosts in HBI:
 ```shell
 # To populate hosts in a WS - note change the pod name
 oc exec -it host-inventory-service-reads-78689bfb96-qhnpr -- /bin/bash
 # Note: grab the Kafka-bootstrap from NS->service and change it below
 NUM_HOSTS=10 KAFKA_BOOTSTRAP_SERVERS=env-ephemeral-7cks0f-da03ec58-kafka-bootstrap.ephemeral-7cks0f.svc:9092 python3 utils/kafka_producer.py
 ```
-4. Assign hosts to the correct org:
+3. Assign hosts to the correct org:
 ```shell
 oc exec -it host-inventory-db-9f6f46699-gwncm -- /bin/bash
 psql
 \c host-inventory
 UPDATE hbi.hosts SET org_id='12345'
 ```
-5. Login to console:
+4. Login to console:
 ```shell
 bonfire namespace describe
 
 will give a gaterway URL wit jdoe|<password>
 ```
-6. Run some checks. e.g. create a workspace in the HBI and check that it replicates into spicedb.
+5. Run some checks. e.g. create a workspace in the HBI and check that it replicates into spicedb.
 
+### Notes
+
+1. The script sets unleash features flags as per `unleash/unleash_project.json`. It will build and deploy
+an image with those feature flags and apply them with bonfire. (If you are not logged into podman it will just 
+use/deploy whatever flags are in `quay.io/mmclaugh/kessel-unleash-import` instead.)
+
+### Checks
+To check unleash feature flags manually:
+```shell
+Log in to Unleash at `localhost:4242` with the creds:
+
+  -   user: admin
+  -   pass: unleash4all
+e.g. check that the `hbi.api.kessel-workspace-migration` in Unleash is on.
+```

--- a/README.md
+++ b/README.md
@@ -51,9 +51,23 @@ will give a gaterway URL wit jdoe|<password>
 
 ### Notes
 
-1. The script sets unleash features flags as per `unleash/unleash_project.json`. It will build and deploy
-an image with those feature flags and apply them with bonfire. (If you are not logged into podman it will just 
-use/deploy whatever flags are in `quay.io/mmclaugh/kessel-unleash-import` instead.)
+#### Unleash Feature Flags Script
+
+1. The script sets Unleash feature flags based on `unleash/unleash_project.json`.  
+   It then builds and deploys an image with these feature flags and applies them using **bonfire**.
+
+#### Possible scenarios
+
+#### A. Not Logged into Podman 
+(recommended if you don't need to set up your own feature flags)
+
+- The script will use the image from `quay.io/mmclaugh/kessel-unleash-import`, which already contains the feature flags.
+
+#### B. Logged into Podman
+
+- The script will create a repository named `kessel-unleash-import` in **your quay account**.
+- **Note:** This may fail the first time — you need to **make the repository public** manually.
+
 
 ### Checks
 To check unleash feature flags manually:

--- a/deploy.sh
+++ b/deploy.sh
@@ -187,6 +187,9 @@ case "$1" in
   clean_download_debezium_configuration)
     clean_download_debezium_configuration
     ;;
+  deploy_unleash_importer_image)
+    deploy_unleash_importer_image
+    ;;
   *)
     usage
     ;;

--- a/deploy.sh
+++ b/deploy.sh
@@ -86,6 +86,8 @@ setup_sink_connector() {
    -p relations-sink-ephemeral/RELATIONS_SINK_IMAGE=$RELATIONS_SINK_IMAGE \
    -p relations-sink-ephemeral/BOOTSTRAP_SERVERS=$BOOTSTRAP_SERVERS \
    -p relations-sink-ephemeral/IMAGE_TAG=$IMAGE_TAG
+
+   deploy_unleash_importer_image
 }
 
 download_debezium_configuration() {
@@ -122,6 +124,52 @@ download_debezium_configuration() {
 clean_download_debezium_configuration() {
   rm -rf deploy
   rm -rf scripts
+}
+
+build_unleash_importer_image() {
+  # This function can probably be split out of the main deploy in the future, since, if the feature flags rarely change,
+  # there will be no need to rebuild the image. By attempting to run it every time for now, we at least test this part
+  # of the script. (The build part is pretty quick anyway.)
+  echo "Attempting to build and push custom unleash image to set feature flags..."
+
+  if ! hash podman 2>/dev/null; then
+    echo "Podman is not installed (and user is also not logged onto quay with podman) -- but don't worry! -- defaulting to pre-built image (quay.io/mmclaugh/kessel-unleash-import:latest) in deployment."
+  else
+    quay_user=$(podman login --get-login quay.io 2>/dev/null || true)
+    if [[ -z "${quay_user}" ]]; then
+      echo "Current user is not logged into quay with podman -- but don't worry! -- defaulting to pre-built image (quay.io/mmclaugh/kessel-unleash-import:latest) in deployment."
+    else
+      IMAGE="quay.io/$quay_user/kessel-unleash-import"
+      TAG="latest"
+      IMAGE_TAG="$IMAGE:$TAG"
+      podman build --platform linux/amd64 . -f docker/Dockerfile.UnleashImporter -t "$IMAGE_TAG"
+      podman push "$IMAGE_TAG"
+      podman rmi "$IMAGE_TAG"
+      echo "Image built, pushed to $IMAGE_TAG and deleted locally."
+      echo "Note: Your quay.io repo needs to be public for the image to be pulled for ephemeral deployments!"
+      UNLEASH_IMAGE="$IMAGE"
+      UNLEASH_TAG="$TAG"
+    fi
+  fi
+}
+
+deploy_unleash_importer_image() {
+  echo "Deploy kessel unleash importer image with feature flags..."
+  build_unleash_importer_image
+
+  if [[ -z "${UNLEASH_IMAGE}" || -z "${UNLEASH_TAG}" ]]; then
+    UNLEASH_IMAGE=quay.io/mmclaugh/kessel-unleash-import
+    UNLEASH_TAG=latest
+  fi
+
+  # Ensure clowdjobinvocations from a prior run are deleted, so that new bonfire run resets flags
+  oc delete --ignore-not-found=true --wait=true clowdjobinvocation/swatch-unleash-import-1
+
+  # Starts the job that runs the unleash feature flag import
+  bonfire deploy rhsm --timeout=1800 --optional-deps-method none  \
+    --frontends false --no-remove-resources app:rhsm \
+    -C rhsm -p rhsm/SWATCH_UNLEASH_IMPORT_IMAGE="$UNLEASH_IMAGE" \
+    -p rhsm/SWATCH_UNLEASH_IMPORT_IMAGE_TAG="$UNLEASH_TAG"
 }
 
 usage() {

--- a/docker/Dockerfile.UnleashImporter
+++ b/docker/Dockerfile.UnleashImporter
@@ -1,0 +1,38 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1747111267
+
+USER root
+
+# Disable all repos except for ubi repos, as ubi repos don't require auth;
+# this makes the container buildable without needing RHEL repos.
+RUN microdnf \
+  --disablerepo=* \
+  --enablerepo=ubi-9-appstream-rpms \
+  --enablerepo=ubi-9-baseos-rpms \
+  install -y jq bash
+
+# ConfigMap is mounted here, but in kessel we ignore it because we bundle config in the image directly.
+RUN mkdir /unleash
+
+WORKDIR /opt/unleash
+
+# This is the file that defines the entire unleash project, including feature flags, environments and statuses.
+COPY unleash/unleash_project.json unleash/import-features.sh .
+
+# This image is intended to be run using a bonfire command like:
+# bonfire deploy rhsm --timeout=1800 --optional-deps-method none  \
+#     --frontends false --no-remove-resources app:rhsm \
+#     -C rhsm -p rhsm/SWATCH_UNLEASH_IMPORT_IMAGE=quay.io/mstead/swatch-unleash-import \
+#     -p rhsm/SWATCH_UNLEASH_IMPORT_IMAGE_TAG=$YOUR_IMAGE_TAG
+# (See https://github.com/RedHatInsights/rhsm-subscriptions/tree/main/swatch-unleash-import.)
+#
+# We are re-using rhsm-subscriptions' good work by taking their deployment template and a modified Dockerfile and
+# import script to apply our feature flags in kessel.
+
+# The rhsm ClowdApp ephemeral config (https://github.com/RedHatInsights/rhsm-subscriptions/blob/main/deploy/rhsm-clowdapp.yaml)
+# that runs the swatch-unleash-import component supplies this image with two arguments, overriding the ones below.
+# This template also takes the flags from a ConfigMap mounted at /unleash, but we don't own it so we can't use it, so
+# instead a customised import-features.sh script takes a hard coded flags file from /opt/unleash/flags.json, instead of
+# the /unleash/flags.json supplied by a volume from the ConfigMap. This is a bit of hack, but it allows us to use the
+# rhsm deployment template without the need to add another component to kessel ephemeral, which is nice.
+
+CMD ["/bin/bash", "/opt/unleash/import-features.sh", "/opt/unleash/flags.json"]

--- a/unleash/import-features.sh
+++ b/unleash/import-features.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# https://github.com/olivergondza/bash-strict-mode
+# This script is adapted from https://github.com/RedHatInsights/rhsm-subscriptions/blob/main/bin/import-features.sh for
+# kessel
+
+set -eEuo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+trap cleanup EXIT
+
+# Note that Unleash will only issue up to a maximum of 10 tokens, so we'll clean up after ourselves
+function cleanup() {
+  # So we don't get a warning about an undefined variable if the trap runs before AUTH_ID is defined
+  AUTH_ID=${AUTH_ID:-}
+  if [ -n "${AUTH_ID}" ]; then
+    curl -v -L -X DELETE "${UNLEASH_URL}/api/admin/user/tokens/${AUTH_ID}" \
+      --header "Authorization: $AUTH_TOKEN"
+  fi
+
+  COOKIE_JAR=${COOKIE_JAR:-}
+  if [ -n "${COOKIE_JAR}" ]; then
+    rm "${COOKIE_JAR}"
+  fi
+}
+
+# Here's how resolution works:
+# * If UNLEASH_HOST is set in the environment, that's the value that's going to be used, period.
+# * If not and the CLOWDER_CONFIG file has featureFlags.hostname, that's the value that will be used
+# * If the CLOWDER_CONFIG file isn't readable or doesn't have featureFlags.hostname, and
+#   UNLEASH_HOST isn't in the environment, default to localhost.
+
+: "${CLOWDER_CONFIG:=/cdapp/cdappconfig.json}"
+if [ -r "${CLOWDER_CONFIG}" ]; then
+  # jq returns "null" instead of the empty string if something isn't there.  We want the empty
+  # string so that later down we can still use parameter substitution to set a default value.  Use
+  # the "//" operator and "empty" operator to effect this.
+  # See https://github.com/jqlang/jq/issues/354#issuecomment-43147898
+  : "${UNLEASH_SCHEME:=$(jq -r '.featureFlags.scheme // empty' "${CLOWDER_CONFIG}")}"
+  : "${UNLEASH_HOST:=$(jq -r '.featureFlags.hostname // empty' "${CLOWDER_CONFIG}")}"
+  : "${UNLEASH_PORT:=$(jq -r '.featureFlags.port // empty' "${CLOWDER_CONFIG}")}"
+fi
+
+: "${UNLEASH_USER:=admin}"
+: "${UNLEASH_PASSWORD:=unleash4all}"
+: "${UNLEASH_SCHEME:=http}"
+: "${UNLEASH_HOST:=localhost}"
+: "${UNLEASH_PORT:=4242}"
+: "${UNLEASH_ADMIN_TOKEN:=}"
+
+UNLEASH_URL="${UNLEASH_SCHEME}://${UNLEASH_HOST}:${UNLEASH_PORT}"
+
+#IMPORT_FILE=${1:-}
+#IMPORT_FILE=/opt/unleash/flags.json
+IMPORT_FILE=/opt/unleash/unleash_project.json
+if [ -z "$IMPORT_FILE" ]; then
+  echo "Usage: $(basename "$0") JSON_FILE"
+  exit 1
+fi
+
+# Unleash offers multiple types of authentication tokens: admin tokens (deprecated), personal
+# access tokens (PATs), and client tokens.  The tokens we care about are the first two.  The
+# problem is that some APIs require PATs and some do not.  Notably the environment import endpoint
+# /api/admin/features-batch/import (see
+# https://docs.getunleash.io/reference/api/unleash/import-toggles and
+# https://docs.getunleash.io/how-to/how-to-environment-import-export#import) *requires* a PAT.
+#
+# We are using an older, deprecated import API /api/admin/state/import (see
+# https://docs.getunleash.io/reference/api/unleash/import and
+# https://docs.getunleash.io/how-to/how-to-import-export) which accepts admin tokens.  We're
+# using this API since it uses the same JSON format as the start-up import (see
+# https://docs.getunleash.io/how-to/how-to-import-export#startup-import) that we use for the local
+# container during development.
+#
+# The expected flow for using PATs seems to be that tokens are created via the web UI.  This won't
+# work for us since we need the whole process to be automated.  PATs can be created via the
+# /api/admin/user/tokens endpoint, but it requires a session cookie.  We can acquire one of
+# those by logging in at /api/admin/user/tokens. The bad part is it requires a user name and
+# password which are *not* provided via clowder!  Nevertheless, I'm adding the code to login and
+# acquire a PAT for the future case when we need to move off of the deprecated import API.
+
+# See https://stackoverflow.com/a/13864829
+if [ -z "${UNLEASH_ADMIN_TOKEN}" ]; then
+  COOKIE_JAR=$(mktemp -t cookie.XXXXX)
+
+  curl -s -S -c "$COOKIE_JAR" -L "${UNLEASH_URL}/auth/simple/login" \
+    --header "Content-Type: application/json" \
+    --data @- > /dev/null <<EOF
+    {
+    "username": "$UNLEASH_USER",
+    "password": "$UNLEASH_PASSWORD"
+    }
+EOF
+
+  AUTH_JSON=$(curl -s -S -b "$COOKIE_JAR" -L "${UNLEASH_URL}/api/admin/user/tokens" \
+    --header "Content-Type: application/json" \
+    --data @- <<EOF
+    {
+    "description": "Admin PAT $(date +%s.%N)",
+    "expiresAt": "$(date -d '+100 years' --utc +%Y-%m-%dT%H:%M:%S)Z"
+    }
+EOF
+  )
+  AUTH_TOKEN="$(echo $AUTH_JSON | jq -r '.secret')"
+  AUTH_ID="$(echo $AUTH_JSON | jq -r '.id')"
+else
+  AUTH_TOKEN="${UNLEASH_ADMIN_TOKEN}"
+fi
+
+# This endpoint "upserts" the "default" project in unleash, meaning all feature flags listed are updated if different
+# to how they are currently configured, or added if they don't already exist, but existing flags remain if they are not
+# listed.
+# Feature flags are fully modifiable afterwards, but reset if this script is run again. (With successive bonfire
+# invocations, the script will not be run again unless the "clowdjobinvocation/swatch-unleash-import-<n>" resource is
+# deleted.)
+curl -L "${UNLEASH_URL}/api/admin/features-batch/import" \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: ${AUTH_TOKEN}" \
+  --data @"${IMPORT_FILE}"

--- a/unleash/unleash_project.json
+++ b/unleash/unleash_project.json
@@ -11,6 +11,24 @@
         "stale": false,
         "impressionData": false,
         "archived": false
+      },
+      {
+        "name": "platform.rbac.workspaces-list",
+        "description": "Enable UI workspace section with v1 role creation wizard.",
+        "type": "release",
+        "project": "default",
+        "stale": false,
+        "impressionData": false,
+        "archived": false
+      },
+      {
+        "name": "platform.rbac.workspaces",
+        "description": "Enable UI workspace section with v2 role creation wizard.",
+        "type": "release",
+        "project": "default",
+        "stale": false,
+        "impressionData": false,
+        "archived": false
       }
     ],
     "featureStrategies": [
@@ -28,6 +46,36 @@
         "variants": [],
         "disabled": false,
         "segments": []
+      },
+      {
+        "name": "flexibleRollout",
+        "id": "7c916df0-7463-4820-960f-43dcd054b6f1",
+        "featureName": "platform.rbac.workspaces-list",
+        "title": null,
+        "parameters": {
+          "groupId": "platform.rbac.workspaces-list",
+          "rollout": "100",
+          "stickiness": "default"
+        },
+        "constraints": [],
+        "variants": [],
+        "disabled": false,
+        "segments": []
+      },
+      {
+        "name": "flexibleRollout",
+        "id": "027cf6d1-cb00-4314-834e-cf2626665431",
+        "featureName": "platform.rbac.workspaces",
+        "title": null,
+        "parameters": {
+          "groupId": "platform.rbac.workspaces",
+          "rollout": "100",
+          "stickiness": "default"
+        },
+        "constraints": [],
+        "variants": [],
+        "disabled": false,
+        "segments": []
       }
     ],
     "featureEnvironments": [
@@ -37,6 +85,20 @@
         "environment": "development",
         "variants": [],
         "name": "hbi.api.kessel-workspace-migration"
+      },
+      {
+        "enabled": true,
+        "featureName": "platform.rbac.workspaces-list",
+        "environment": "development",
+        "variants": [],
+        "name": "platform.rbac.workspaces-list"
+      },
+      {
+        "enabled": false,
+        "featureName": "platform.rbac.workspaces",
+        "environment": "development",
+        "variants": [],
+        "name": "platform.rbac.workspaces"
       }
     ],
     "contextFields": [],

--- a/unleash/unleash_project.json
+++ b/unleash/unleash_project.json
@@ -1,0 +1,48 @@
+{
+  "project": "default",
+  "environment": "development",
+  "data": {
+    "features": [
+      {
+        "name": "hbi.api.kessel-workspace-migration",
+        "description": "Gates the functionality for Phase 0 of the HBI Kessel migration (RHINENG-15827).",
+        "type": "release",
+        "project": "default",
+        "stale": false,
+        "impressionData": false,
+        "archived": false
+      }
+    ],
+    "featureStrategies": [
+      {
+        "name": "flexibleRollout",
+        "id": "86a0f037-be42-45c5-a924-1bbb2dc5594e",
+        "featureName": "hbi.api.kessel-workspace-migration",
+        "title": null,
+        "parameters": {
+          "groupId": "hbi.api.kessel-workspace-migration",
+          "rollout": "100",
+          "stickiness": "default"
+        },
+        "constraints": [],
+        "variants": [],
+        "disabled": false,
+        "segments": []
+      }
+    ],
+    "featureEnvironments": [
+      {
+        "enabled": true,
+        "featureName": "hbi.api.kessel-workspace-migration",
+        "environment": "development",
+        "variants": [],
+        "name": "hbi.api.kessel-workspace-migration"
+      }
+    ],
+    "contextFields": [],
+    "featureTags": [],
+    "segments": [],
+    "tagTypes": [],
+    "dependencies": []
+  }
+}


### PR DESCRIPTION
1. Rather than port-forwarding and logging into the unleash console and setting the feature flag manually each time, the script now uses a mechanism taken from `rhsm-subscriptions` to build an image containing a json of the project feature flags and apply them in ephemeral using bonfire.
2. Feature flags can be set in `unleash/unleash_project.json`.
3. A new `latest` image is built each time and pushed to the user's quay repo if podman is installed and the user is logged in. Otherwise, it defaults to whatever is set in `quay.io/mmclaugh/kessel-unleash-import`.
4. README updated with same.