### PR TITLE
Harden rbac migration

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -33,7 +33,7 @@ deploy() {
   -p rbac/REPLICATION_TO_RELATION_ENABLED=True -p rbac/BYPASS_BOP_VERIFICATION=True \
   -p rbac/KAFKA_ENABLED=False -p rbac/NOTIFICATONS_ENABLED=False \
   -p rbac/NOTIFICATIONS_RH_ENABLED=False \
- -p rbac/ROLE_CREATE_ALLOW_LIST="remediations,\
+  -p rbac/ROLE_CREATE_ALLOW_LIST="remediations,\
 inventory,\
 policies,\
 advisor,\
@@ -47,6 +47,7 @@ ros,\
 staleness,\
 config-manager,\
 idmsvc" \
+  -p rbac/V2_MIGRATION_APP_EXCLUDE_LIST="approval" \
   --set-image-tag quay.io/cloudservices/insights-inventory=latest \
   --set-image-tag quay.io/cloudservices/insights-inventory-frontend="${HOST_FRONTEND_GIT_COMMIT}" \
   --set-image-tag quay.io/redhat-services-prod/hcc-platex-services/chrome-service=latest \


### PR DESCRIPTION
- Add `rbac/V2_MIGRATION_APP_EXCLUDE_LIST="approval"` to rbac bonfire command.
- Force re-seeding of rbac data after replication slot has been created by debezium.