### PR TITLE
RHCLOUD-40415 - Deploy latest spicedb schema from rbac-config

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -126,7 +126,15 @@ setup_kessel() {
   echo "Kessel inventory is setting up.."
   bonfire deploy kessel -C kessel-inventory --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=latest
 
+  apply_latest_schema
   setup_sink_connector
+}
+
+apply_latest_schema() {
+  echo "Applying latest SpiceDB schema from rbac-config"
+  curl -o schema.zed https://raw.githubusercontent.com/RedHatInsights/rbac-config/refs/heads/master/configs/stage/schemas/schema.zed
+  oc create configmap spicedb-schema --from-file=schema.zed -o yaml --dry-run=client | oc apply -f -
+  rm schema.zed
 }
 
 setup_sink_connector() {


### PR DESCRIPTION
Pulls the latest spicedb schema from rbac-config.
Updates the `spicedb-schema` configmap with the latest schema

For: https://issues.redhat.com/browse/RHCLOUD-40415