### PR TITLE
RHCLOUD-40610: Harden the error detection and retry mechanism for OOM errors

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -107,16 +107,17 @@ setup_debezium() {
 
 # workaround for the case where seeding attempted before replication slot has been created for debezium and events are lost
 force_seed_rbac_data_in_relations() {
-  echo "Force (re-)seeding of rbac data in kessel..."
+  echo "Force re-seeding of rbac permissions, roles and groups in kessel..."
   echo "Wait for rbac debezium connector to be ready to ensure replication slot has been created..."
   oc wait kafkaconnector/rbac-connector --for=condition=Ready --timeout=300s
-  echo "Run seeding script..."
   RBAC_SERVICE_POD=$(oc get pods -l pod=rbac-service --no-headers -o custom-columns=":metadata.name" --field-selector=status.phase==Running | head -1)
   while true; do
-    OUTPUT=$(oc exec -it "$RBAC_SERVICE_POD" --container=rbac-service -- /bin/bash -c "./rbac/manage.py seeds --force-create-relationships" 2>&1 | grep -F 'INFO: ***' || true)
-    if [ -z "$OUTPUT" ]; then
-      echo "Rbac service pod was OOMKilled or otherwise unavailable when attempting to run the seed script. Retrying in 5s..."
-      sleep 5
+    OUTPUT=$(oc exec -it "$RBAC_SERVICE_POD" --container=rbac-service -- /bin/bash -c "./rbac/manage.py seeds --force-create-relationships"  | grep -E 'INFO: \*\*\*|ERROR:')
+    EXIT_STATUS=$?
+    if [ $EXIT_STATUS -ne 0 ]; then
+      echo "Rbac service pod was OOMKilled or was otherwise unavailable when attempting to run the seed script. Trying again..."
+      oc rollout status deployment/rbac-service -w
+      RBAC_SERVICE_POD=$(oc get pods -l pod=rbac-service --no-headers -o custom-columns=":metadata.name" --field-selector=status.phase==Running | head -1)
     else
       break
     fi


### PR DESCRIPTION
1. Test exit code instead of script output as a more reliable measure of command success.
2. In the event of a failure, OOM or otherwise, wait for the deployment to become ready, and fetch the pod reference only afterwards, before re-running the script. (This ensures that retries are not performed while the pod is coming back, or against a non-existent pod.)
3. Expose error output (if any) to the terminal.