### PR TITLE
RHCLOUD-40696: Fix intermittent issue with rbac seeding where error executing command

### DIFF
--- a/scripts/rbac_seed_users.sh
+++ b/scripts/rbac_seed_users.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 NAMESPACE=`oc project -q 2>/dev/null || true`
-RBAC_SERVICE_POD=$(oc get pods -l pod=rbac-service --no-headers -o custom-columns=":metadata.name" --field-selector=status.phase==Running | head -1)
+RBAC_SERVICE_POD=$(oc get pods -l pod=rbac-service -o json | jq -r '.items[] | select(.status.phase == "Running" and .metadata.deletionTimestamp == null) | .metadata.name' | head -n 1)
 
 USER_FILE="./data/rbac_users_data.json" 
 # --- Check if the JSON file exists ---
@@ -58,7 +58,7 @@ EOF"
   if [ $EXIT_STATUS -ne 0 ]; then
       echo "Rbac service pod was OOMKilled or was otherwise unavailable when attempting to run the user seed script. Trying again..."
       oc rollout status deployment/rbac-service -w
-      RBAC_SERVICE_POD=$(oc get pods -l pod=rbac-service --no-headers -o custom-columns=":metadata.name" --field-selector=status.phase==Running | head -1)
+      RBAC_SERVICE_POD=$(oc get pods -l pod=rbac-service -o json | jq -r '.items[] | select(.status.phase == "Running" and .metadata.deletionTimestamp == null) | .metadata.name' | head -n 1)
     else
       break
     fi


### PR DESCRIPTION
## Changes
- Makes rbac service pod selection more robust, so the correct pod is selected for `oc exec`.

## Problem

Address issue where once every 4 or 5 times the deployer script is run, the `
force_seed_rbac_data_in_relations` function fails with 
```
error: Internal error occurred: error executing command in container: container is not created or running
```
Issue explained:
```
For some reason, kubernetes sometimes schedules 2 rbac service pods rather than 1. It then schedules 1 of them for deletion. Even though the deployer script waits for the rbac deployment to be complete and checks that the pod is running -- both of which are true -- it can still be the case that it execs into the pod that is scheduled for deletion as it is shutting down.
The solution is to grab not only a running pod but one that does not have a deletionTimestamp, in which case it picks the right pod.

It would only occur shortly after rbac is deployed, when the deployment is complete but it hasn't managed to get the second pod deleted yet.

It's a race condition, because eventually the pod moves to "Terminating", but by then the pod has been picked for the exec.
```