### PR TITLE
readme: add oc login command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ EPHEMERAL_TOKEN can be obtained from https://oauth-openshift.apps.crc-eph.r9lp.p
 git clone git@github.com:project-kessel/insights-service-deployer.git
 export EPHEMERAL_TOKEN=<> # get token from ephemeral cluster
 export EPHEMERAL_SERVER=<> # get server from ephemeral cluster
+# log into ephemeral cluster
+oc login --token="${EPHEMERAL_TOKEN}" --server="${EPHEMERAL_SERVER}" 
 ./deploy.sh deploy
 ```
 


### PR DESCRIPTION
#### Changes:
- Add oc login command to readme

#### Description: 
My first time setting up insights-service-deployer I recieved the error:
```
❯ ./deploy.sh deploy_with_hbi_demo
Error from server (Forbidden): users.user.openshift.io "apis" is forbidden: User "aobrien" cannot get resource "users/user.openshift.io" in API group "user.openshift.io" at the cluster scope
```

This happened because I wasn't logged in with `oc login`