### PR TITLE
Have deploy.sh Set Ephemeral token and server

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+EPHEMERAL_TOKEN=$(oc whoami --show-token)
+EPHEMERAL_SERVER=$(oc whoami --show-server)
+
 login() {
   user="$(oc whoami < /dev/null)"
   [[ $? -eq 0 ]] && echo "Skipping login. Already logged in as user: $user" && return 0


### PR DESCRIPTION
With ephemeral namespaces being moody and fragile, I recreate them every day.  That's creating this PR so there are two fewer commands to run.  I did not update the README, just incase `$EPHEMERAL_TOKEN` and `$EPHEMERAL_SERVER` are used other places. 