### PR TITLE
adds KIC to deployer script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -40,7 +40,7 @@ deploy() {
   HBI_CUSTOM_IMAGE_TAG=latest
   HBI_CUSTOM_IMAGE_PARAMETER=""
   LOCAL_SCHEMA_FILE=""
-  
+
   if [ -n "$1" ]; then
     HBI_DEPLOYMENT_TEMPLATE_REF="$1"
   else
@@ -146,6 +146,7 @@ setup_kessel() {
   bonfire deploy kessel -C kessel-inventory --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=latest
 
   setup_sink_connector
+  setup_kessel_inventory_consumer
 }
 
 apply_schema() {
@@ -183,6 +184,11 @@ apply_schema() {
 setup_sink_connector() {
   echo "Relations sink connector is setting up.."
   bonfire deploy kessel -C relations-sink-ephemeral
+}
+
+setup_kessel_inventory_consumer() {
+  echo "Kessel Inventory Consumer is setting up.."
+  bonfire deploy kessel -C kessel-inventory-consumer
 }
 
 download_debezium_configuration() {
@@ -436,7 +442,7 @@ case "$1" in
     ;;
   iqe)
     iqe
-    ;; 
+    ;;
   *)
     usage
     ;;


### PR DESCRIPTION
Adds Kessel Inventory Consumer and dependencies to deployer script for testing replication from HBI to Inventory in ephemeral

Changes:
* adds function and bonfire deploy command to deploy kessel-inventory-consumer
  * this deployment also includes a separate kafka connect cluster to be used by HBI specific  debezium connector (to come in a later PR from Tyler)
  * no noticeable impact on startup time with inclusion of connect (there are other services that still start after connect was running)
  * some extra white space removal

Validation:
I tested the script in ephemeral and all services ran as expected, and i was able to successfully add  hosts to HBI using script

```shell
No failing pods
$ oc get pods --no-headers | grep -v -E "Running|Completed" -c
0

# all kessel pods running including new consumer pod
$ oc get pods | grep kessel
kessel-inventory-api-766d965b6b-dcg6s                             2/2     Running     0             39m
kessel-inventory-consumer-service-5bbfbb6b67-jndmd                1/1     Running     0             39m
kessel-inventory-db-555667f58-d6vm5                               1/1     Running     0             42m
kessel-kafka-connect-connect-0                                    1/1     Running     0             39m
kessel-relations-api-664fc94578-8vp9n                             2/2     Running     0             34m

# new kessel connect running (used solely by kessel inventory consumer for HBI migration testing)
$ oc get kc kessel-kafka-connect
NAME                   DESIRED REPLICAS   READY
kessel-kafka-connect   1                  True

# test connector for HBI migration running (coming in future PR)
$ oc get kctr hbi-connector 
NAME            CLUSTER                CONNECTOR CLASS                                      MAX TASKS   READY
hbi-connector   kessel-kafka-connect   io.debezium.connector.postgresql.PostgresConnector   1           True

# tested migration event using add_hosts_to_hbi script option
$ ./deploy.sh add_hosts_to_hbi 12345 1
Sending 1 hosts to hbi using kafka producer...
Number of hosts (payloads):  1
HOST_INGRESS_TOPIC: platform.inventory.host-ingress
% Message delivered to platform.inventory.host-ingress [0] @ 1
Waiting for 1 hosts added via kafka to sync to the hbi db... [AFTER_COUNT: 1, TARGET_COUNT: 2]
Waiting for 1 hosts added via kafka to sync to the hbi db... [AFTER_COUNT: 1, TARGET_COUNT: 2]
Done. [AFTER_COUNT: 2, TARGET_COUNT: 2]

# KIC logs showing event processed
INFO ts=2025-07-08T14:36:19Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=processing message: operation=migration
INFO ts=2025-07-08T14:36:19Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=response: 
INFO ts=2025-07-08T14:36:19Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=consumed event from topic host-inventory.hbi.hosts, partition 2 at offset 1
INFO ts=2025-07-08T14:42:21Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=processing message: operation=migration
INFO ts=2025-07-08T14:42:21Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=response: 
INFO ts=2025-07-08T14:42:21Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=offsets committed ([partition:offset]): [0:0],[2:1]
INFO ts=2025-07-08T14:42:21Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=consumed event from topic host-inventory.hbi.hosts, partition 0 at offset 0

# resource created in inventory DB as expected and replication to Relations completed by inventory as well
# from inventory DB
-[ RECORD 1 ]--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
id                   | 0197ea77-5720-7b7c-9eb7-c0fab3a78f41
inventory_id         | 0197ea77-571f-7ed9-8ce6-bd39547b43dc
org_id               | 
resource_data        | {"type": "host", "reporter_type": "hbi", "representations": {"common": {"workspace_id": "12345"}, "metadata": {"api_href": "https://apiHref.com/", "console_href": "https://www.console.com/", "reporter_version": "1.0", "local_resource_id": "12a11672-b5d5-4d85-95dc-8c1f2028b36b"}, "reporter": {"ansible_host": "", "satellite_id": "cf9cc4ce-ca01-46fd-8d2f-0baffaa739c8", "sub_manager_id": "d02940e9-2944-4e17-adec-a2a697a516c4", "insights_inventory_id": "538cba1d-bc17-4914-95dd-b3565a7c2935"}}, "reporter_instance_id": "12a11672-b5d5-4d85-95dc-8c1f2028b36b"}
resource_type        | host
workspace_id         | 12345
console_href         | https://www.console.com/
api_href             | https://apiHref.com/
labels               | null
created_at           | 2025-07-08 14:36:19.104756+00
updated_at           | 2025-07-08 14:36:19.688631+00
consistency_token    | GgYKBENMOFM=
reporter_resource_id | 12a11672-b5d5-4d85-95dc-8c1f2028b36b
reporter_type        | hbi
reporter_instance_id | 12a11672-b5d5-4d85-95dc-8c1f2028b36b
reporter_version     | 1.0
reporter_id          | grpc-go/1.73.0
reporter             | {"reporter_id": "", "reporter_type": "", "reporter_version": "", "local_resource_id": ""}

# from inventory api pod logs showing consumption (consistency token above reflects processing too)
INFO ts=2025-07-08T14:43:07Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=processing message: operation=created, txid=
INFO ts=2025-07-08T14:43:07Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=consumed event from topic outbox.event.kessel.tuples, partition 0 at offset 2
```

  