### PR TITLE
Remove generic "up" option because we cant run customizations

### DIFF
--- a/okteto-dev.sh
+++ b/okteto-dev.sh
@@ -436,12 +436,6 @@ okteto_down() {
     
     log "All development containers cleaned up"
     
-    # Clean up deployment customizations for all services that were active
-    log "Cleaning up deployment customizations..."
-    for service in $active; do
-        scripts/customize_deployments.sh "$service" down
-    done
-    
     # Clean up temporary okteto.yaml if we created it
     if [[ "$created_temp_yaml" == "true" ]]; then
         log "Cleaning up temporary okteto.yaml"


### PR DESCRIPTION
When okteto creates development deployments, it copies most of the config from the deployments it replaces. However, it gives you limited ability to alter those deployments. What we can do instead is edit the original deployment after Clowder reconciliation is disabled, but before okteto runs, to customize the deployment that okteto creates. The original deployment is put back to the way it was afterwards.

One reason this is required is to extend readiness/liveness probe (needed for daemon mode) wait times to prevent pods getting killed prematurely by kubernetes. This happens for the HBI mq pods because development mode pods take longer to come up due to the need for installing a debugger, etc.

To patch this, we run `scripts/customize_deployments.sh` `up` each time a service comes up and `down` each time a service goes down, in order to apply any customizations we might need.

In the above example, we extend the liveness timeouts, and return them back to normal afterwards (which clowder will do anyway when it is enabled). 