### PR TITLE
Add partition and delete support for host replication

### DIFF
--- a/deploy/debezium-connector-hosts.yml
+++ b/deploy/debezium-connector-hosts.yml
@@ -1,3 +1,4 @@
+# debezium v2.7
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -29,18 +30,20 @@ objects:
       database.user: ${secrets:host-inventory-db:db.user}
       database.password: ${secrets:host-inventory-db:db.password}
       topic.prefix: host-inventory
-      table.whitelist: hbi.hosts
-      table.include.list: hbi.hosts
+      table.include.list: hbi.hosts_p.*
       plugin.name: pgoutput
       heartbeat.interval.ms: ${DEBEZIUM_HEARTBEAT_INTERVAL_MS}
       heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
       topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
       # Transform configurations
-      transforms: "unwrap,addMetadata,addHeaders,fieldFilter"
+      transforms: "route,unwrap,addMetadata,addHeaders,fieldFilter"
       # Extract new record state (flatten envelope)
       transforms.unwrap.type: "io.debezium.transforms.ExtractNewRecordState"
       transforms.unwrap.drop.tombstones: "false"
-      transforms.unwrap.delete.handling.mode: "rewrite"
+      # Route partition tables to logical table topic
+      transforms.route.type: "io.debezium.transforms.ByLogicalTableRouter"
+      transforms.route.topic.regex: "host-inventory\\.hbi\\.hosts.*"
+      transforms.route.topic.replacement: "host-inventory.hbi.hosts"
       # Add source metadata to payload
       transforms.addMetadata.type: "org.apache.kafka.connect.transforms.InsertField$Value"
       transforms.addMetadata.static.field: "source_system"


### PR DESCRIPTION
- Updates the host connector to leverage host partitions and combine routing to a single topic
- Updates the host connector to remove rewriting delete messages (tombstones only)