### PR TITLE
RHCLOUD-41667: updates connectors for outbox changes + migration cleanup script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -43,7 +43,7 @@ deploy() {
   HBI_CUSTOM_IMAGE_TAG=latest
   HBI_CUSTOM_IMAGE_PARAMETER=""
   LOCAL_SCHEMA_FILE=""
-  
+
   if [ -n "$1" ]; then
     HBI_DEPLOYMENT_TEMPLATE_REF="$1"
   else
@@ -366,25 +366,26 @@ create_hbi_connectors() {
 # TODO: remove this once we have a proper outbox table in the hbi db (RHINENG-19194)
 create_hbi_tables() {
   echo "Creating outbox and signal tables in host-inventory-db hbi schema..."
-  
+
   HOST_INVENTORY_DB_POD=$(oc get pods -l app=host-inventory,service=db,sub=local_db --no-headers -o custom-columns=":metadata.name" --field-selector=status.phase==Running | head -1)
-  
+
   if [ -z "$HOST_INVENTORY_DB_POD" ]; then
     echo "Error: Could not find host-inventory database pod"
     exit 1
   fi
-  
+
   echo "Using database pod: $HOST_INVENTORY_DB_POD"
-  
+
   # Create hbi schema if it doesn't exist
   oc exec -it "$HOST_INVENTORY_DB_POD" -- /bin/bash -c "psql -d host-inventory -c \"CREATE SCHEMA IF NOT EXISTS hbi;\""
-  
+
   # Create outbox table
   oc exec -it "$HOST_INVENTORY_DB_POD" -- /bin/bash -c "psql -d host-inventory -c \"CREATE TABLE IF NOT EXISTS hbi.outbox (
     id uuid NOT NULL,
     aggregatetype character varying(255) NOT NULL,
     aggregateid character varying(255) NOT NULL,
-    event_type character varying(255) NOT NULL,
+    operation character varying(255) NOT NULL,
+    version character varying(255) NOT NULL,
     payload jsonb
   );\""
 
@@ -499,7 +500,7 @@ case "$1" in
     ;;
   iqe)
     iqe
-    ;; 
+    ;;
   *)
     usage
     ;;

--- a/deploy/debezium-connector-hosts-outbox.yml
+++ b/deploy/debezium-connector-hosts-outbox.yml
@@ -27,7 +27,7 @@ objects:
       table.include.list: hbi.outbox
       transforms: outbox
       transforms.outbox.type: io.debezium.transforms.outbox.EventRouter
-      transforms.outbox.table.fields.additional.placement: event_type:header:operation
+      transforms.outbox.table.fields.additional.placement: operation:header,version:header
       transforms.outbox.table.expand.json.payload: true
       value.converter: org.apache.kafka.connect.json.JsonConverter
       plugin.name: pgoutput

--- a/deploy/debezium-connector-hosts.yml
+++ b/deploy/debezium-connector-hosts.yml
@@ -22,7 +22,6 @@ objects:
       signal.kafka.topic: "host-inventory.signal"
       signal.kafka.bootstrap.servers: "${ENV_NAME}-kafka-bootstrap:9092"
       signal.data.collection: "hbi.signal"
-      snapshot.mode: "no_data"
       database.server.name: host-inventory-db
       database.dbname: ${secrets:host-inventory-db:db.name}
       database.hostname: ${secrets:host-inventory-db:db.host}
@@ -36,7 +35,7 @@ objects:
       heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
       topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
       # Transform configurations
-      transforms: "route,unwrap,addMetadata,addHeaders,fieldFilter"
+      transforms: "route,unwrap,addMetadata,addOpHeader,addVerHeader,fieldFilter"
       # Extract new record state (flatten envelope)
       transforms.unwrap.type: "io.debezium.transforms.ExtractNewRecordState"
       transforms.unwrap.drop.tombstones: "false"
@@ -49,10 +48,12 @@ objects:
       transforms.addMetadata.static.field: "source_system"
       transforms.addMetadata.static.value: "host-inventory-db"
       # Add static headers
-      transforms.addHeaders.type: "org.apache.kafka.connect.transforms.InsertHeader"
-      transforms.addHeaders.header: "operation"
-      transforms.addHeaders.value.literal: "migration"
-      # Filter only fields we want to migrate
+      transforms.addOpHeader.type: "org.apache.kafka.connect.transforms.InsertHeader"
+      transforms.addOpHeader.header: "operation"
+      transforms.addOpHeader.value.literal: "migration"
+      transforms.addVerHeader.type: "org.apache.kafka.connect.transforms.InsertHeader"
+      transforms.addVerHeader.header: "version"
+      transforms.addVerHeader.value.literal: "v1beta2"
       transforms.fieldFilter.type: "org.apache.kafka.connect.transforms.ReplaceField$Value"
       transforms.fieldFilter.include: "id,ansible_host,insights_id,satellite_id,subscription_manager_id,groups"
 

--- a/scripts/migration-cleanup.sh
+++ b/scripts/migration-cleanup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Remove connectors
+echo "Removing connectors..."
+oc delete kctr hbi-migration-connector hbi-outbox-connector
+
+# clean up KIC and Connect
+echo "Removing Connect and KIC..."
+oc delete app kessel-inventory-consumer
+oc delete kc kessel-kafka-connect
+
+# remove connect and migration/outbox topics
+echo "Removing topics..."
+NAMESPACE=env-$(oc project -q)
+BOOTSTRAP_SERVERS=${NAMESPACE}-kafka-bootstrap:9092
+for i in kessel-kafka-connect-cluster-configs kessel-kafka-connect-cluster-offsets kessel-kafka-connect-cluster-status host-inventory.hbi.hosts outbox.event.hbi.hosts; do oc rsh $NAMESPACE-kafka-0 /opt/kafka/bin/kafka-topics.sh --delete --bootstrap-server $BOOTSTRAP_SERVERS --topic $i; done
+
+# remove any test hosts from HBI DB
+echo "Removing any host records..."
+HOST_DB_POD=$(oc get pod --no-headers -o name -l app=host-inventory,service=db,sub=local_db)
+oc rsh $HOST_DB_POD psql -d host-inventory -c "delete from hbi.hosts;"
+
+echo "Removing replication slots..."
+oc rsh $HOST_DB_POD psql -d host-inventory -c "select pg_drop_replication_slot('debezium_hosts'); select pg_drop_replication_slot('debezium_outbox');"
+
+oc rsh $HOST_DB_POD psql -d host-inventory -c "drop table hbi.outbox; drop table hbi.signal"
+echo "Done!"


### PR DESCRIPTION
Updates to support header changes in RHCLOUD-41667:
* Updates the temp outbox table script to add operation and versions columns
* Updates HBI connectors to ensure the headers are properly setup and processed in messages
* adds a migration-cleanup script for undoing all the changes made by the `host-replication-kafka` and `host-replication-tables` commands