### PR TITLE
Reserve a namespace if we are using the default one

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -21,8 +21,8 @@ login() {
 
 check_bonfire_namespace() {
   NAMESPACE=`oc project -q 2>/dev/null || true`
-  if [[ -z $NAMESPACE ]]; then
-    echo "No bonfire namespace set, reserving a namespace for you now (duration 10hr)..."
+  if [[ -z $NAMESPACE || "${NAMESPACE}" == "default" ]]; then
+    echo "No bonfire namespace set or using 'default', reserving a namespace for you now (duration 10hr)..."
     bonfire namespace reserve --duration 10h
   fi
 }


### PR DESCRIPTION
This is something that I have been hitting, not a big issue, but had to reserve manually.
I think we reset to the default namespace when using `bonfire namespace release`