### PR TITLE
removes db table removal from cleanup script, updates runbook for outbox delete testing

### DIFF
--- a/scripts/migration-cleanup.sh
+++ b/scripts/migration-cleanup.sh
@@ -23,5 +23,4 @@ oc rsh $HOST_DB_POD psql -d host-inventory -c "delete from hbi.hosts;"
 echo "Removing replication slots..."
 oc rsh $HOST_DB_POD psql -d host-inventory -c "select pg_drop_replication_slot('debezium_hosts'); select pg_drop_replication_slot('debezium_outbox');"
 
-oc rsh $HOST_DB_POD psql -d host-inventory -c "drop table hbi.outbox; drop table hbi.signal"
 echo "Done!"


### PR DESCRIPTION
Updates for migration/outbox testing
* removes the outbox/signal table cleanup steps in the migration cleanup script since those are handled by HBI (signal table coming soon)
* updates outbox testing steps to include a delete test
* updates deployment scripts to use hbi demo version to create some hosts from the start (for basic testing)
* updates some of the sql queries for schema changes in kessel inventory