### PR TITLE
re-apply schema on deploy_with_hbi_demo

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -448,6 +448,7 @@ case "$1" in
     oc patch kafkaconnector "hbi-outbox-connector" --type='merge' -p='{"spec":{"state":"running"}}'
     add_users
     add_hosts_to_hbi
+    apply_schema "$5"
     show_bonfire_namespace
     ;;
   clean_download_debezium_configuration)


### PR DESCRIPTION
 - At some point after the `deploy` function - the spicedb-schema config gets reconfigured. I saw this in the logs and the spicedb-schema had a different content. 
  
It was (apparently) caused by a bonfire command, unsure which one, but this happen after `deploy`.
I'm applying the schema again to ensure it's using the one specified.

This is more like a way to point out the issue, feel free to close if there are a better ways to fix this.