### PR TITLE
updating commands

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -81,7 +81,7 @@ deploy() {
   -p kessel-relations/SPICEDB_CPU_REQUEST=1000m \
   -p kessel-relations/SPICEDB_MEMORY_LIMIT=512Mi \
   -p kessel-relations/SPICEDB_CPU_LIMIT=1000m \
-  --no-remove-resources all
+  --no-remove-resources all \
   -p rbac/ROLE_CREATE_ALLOW_LIST="remediations,\
 inventory,\
 policies,\

--- a/deploy.sh
+++ b/deploy.sh
@@ -98,7 +98,8 @@ idmsvc" \
   -p host-inventory/BYPASS_RBAC=false \
   -p host-inventory/BYPASS_KESSEL=false \
   --set-image-tag quay.io/cloudservices/unleash-proxy=latest \
-  --set-image-tag quay.io/redhat-services-prod/rh-platform-experien-tenant/insights-rbac-ui=latest
+  --set-image-tag quay.io/redhat-services-prod/rh-platform-experien-tenant/insights-rbac-ui=latest \
+  --no-remove-resources all
 
   setup_rbac_debezium
   apply_schema "$LOCAL_SCHEMA_FILE"
@@ -189,7 +190,16 @@ idmsvc" \
 
 setup_kessel() {
   echo "Kessel inventory is setting up.."
-  bonfire deploy kessel -C kessel-inventory -C kessel-relations --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=latest -p kessel-relations/SPICEDB_QUANTIZATION_INTERVAL=2.5s -p kessel-relations/SPICEDB_QUANTIZATION_STALENESS_PERCENT=0
+  bonfire deploy kessel -C kessel-inventory -C kessel-relations --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=latest -p kessel-relations/SPICEDB_QUANTIZATION_INTERVAL=2.5s -p kessel-relations/SPICEDB_QUANTIZATION_STALENESS_PERCENT=0 \
+  -p kessel-relations/SPICEDB_POSTGRES_CPU_LIMIT=2000m \
+  -p kessel-relations/SPICEDB_POSTGRES_CPU_REQUEST=2000m \
+  -p kessel-relations/SPICEDB_POSTGRES_MEMORY_LIMIT=512Mi \
+  -p kessel-relations/SPICEDB_POSTGRES_MEMORY_REQUEST=512Mi \
+  -p kessel-relations/SPICEDB_MEMORY_REQUEST=512Mi \
+  -p kessel-relations/SPICEDB_CPU_REQUEST=1000m \
+  -p kessel-relations/SPICEDB_MEMORY_LIMIT=512Mi \
+  -p kessel-relations/SPICEDB_CPU_LIMIT=1000m \
+  --no-remove-resources all
 }
 
 apply_schema() {
@@ -230,7 +240,16 @@ apply_schema() {
 setup_kessel_inventory_consumer() {
   echo "Kessel Inventory Consumer is setting up.."
   # Add kessel-relations parameters again, otherwise it gets redeployed with default params
-  bonfire deploy kessel -C kessel-inventory-consumer -p kessel-relations/SPICEDB_QUANTIZATION_INTERVAL=2.5s -p kessel-relations/SPICEDB_QUANTIZATION_STALENESS_PERCENT=0
+  bonfire deploy kessel -C kessel-inventory-consumer -p kessel-relations/SPICEDB_QUANTIZATION_INTERVAL=2.5s -p kessel-relations/SPICEDB_QUANTIZATION_STALENESS_PERCENT=0 \
+  -p kessel-relations/SPICEDB_POSTGRES_CPU_LIMIT=2000m \
+  -p kessel-relations/SPICEDB_POSTGRES_CPU_REQUEST=2000m \
+  -p kessel-relations/SPICEDB_POSTGRES_MEMORY_LIMIT=512Mi \
+  -p kessel-relations/SPICEDB_POSTGRES_MEMORY_REQUEST=512Mi \
+  -p kessel-relations/SPICEDB_MEMORY_REQUEST=512Mi \
+  -p kessel-relations/SPICEDB_CPU_REQUEST=1000m \
+  -p kessel-relations/SPICEDB_MEMORY_LIMIT=512Mi \
+  -p kessel-relations/SPICEDB_CPU_LIMIT=1000m \
+  --no-remove-resources all
 }
 
 download_debezium_configuration() {

--- a/deploy.sh
+++ b/deploy.sh
@@ -156,7 +156,6 @@ force_seed_rbac_data_in_relations() {
   done
   echo "$OUTPUT"
 
-  setup_kessel
   setup_rbac_consumer
 }
 
@@ -195,20 +194,6 @@ idmsvc" \
     -p rbac/V2_MIGRATION_APP_EXCLUDE_LIST="approval" \
     -p rbac/V2_MIGRATION_RESOURCE_EXCLUDE_LIST="empty-exclude-list" \
     --namespace $NAMESPACE | oc apply -f - -n $NAMESPACE
-}
-
-setup_kessel() {
-  echo "Kessel inventory is setting up.."
-  bonfire deploy kessel -C kessel-inventory -C kessel-relations --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=latest -p kessel-relations/SPICEDB_QUANTIZATION_INTERVAL=2.5s -p kessel-relations/SPICEDB_QUANTIZATION_STALENESS_PERCENT=0 \
-  -p kessel-relations/SPICEDB_POSTGRES_CPU_LIMIT=2000m \
-  -p kessel-relations/SPICEDB_POSTGRES_CPU_REQUEST=2000m \
-  -p kessel-relations/SPICEDB_POSTGRES_MEMORY_LIMIT=512Mi \
-  -p kessel-relations/SPICEDB_POSTGRES_MEMORY_REQUEST=512Mi \
-  -p kessel-relations/SPICEDB_MEMORY_REQUEST=512Mi \
-  -p kessel-relations/SPICEDB_CPU_REQUEST=1000m \
-  -p kessel-relations/SPICEDB_MEMORY_LIMIT=512Mi \
-  -p kessel-relations/SPICEDB_CPU_LIMIT=1000m \
-  --no-remove-resources all
 }
 
 apply_schema() {

--- a/deploy.sh
+++ b/deploy.sh
@@ -73,6 +73,15 @@ deploy() {
   -p rbac/REPLICATION_TO_RELATION_ENABLED=True \
   -p rbac/KAFKA_ENABLED=False -p rbac/NOTIFICATONS_ENABLED=False \
   -p rbac/NOTIFICATIONS_RH_ENABLED=False \
+  -p kessel-relations/SPICEDB_POSTGRES_CPU_LIMIT=2000m \
+  -p kessel-relations/SPICEDB_POSTGRES_CPU_REQUEST=2000m \
+  -p kessel-relations/SPICEDB_POSTGRES_MEMORY_LIMIT=512Mi \
+  -p kessel-relations/SPICEDB_POSTGRES_MEMORY_REQUEST=512Mi \
+  -p kessel-relations/SPICEDB_MEMORY_REQUEST=512Mi \
+  -p kessel-relations/SPICEDB_CPU_REQUEST=1000m \
+  -p kessel-relations/SPICEDB_MEMORY_LIMIT=512Mi \
+  -p kessel-relations/SPICEDB_CPU_LIMIT=1000m \
+  --no-remove-resources all
   -p rbac/ROLE_CREATE_ALLOW_LIST="remediations,\
 inventory,\
 policies,\


### PR DESCRIPTION
## Purpose

Running the IQE tests are taking 5x longer in the ephemeral environment when Kessel is enabled. We suspect that the resources defined were far too low and causing the slowness. This PR serves as a test for us to validate this hypothesis and likely wont be merged. 