### PR TITLE
[RHCLOUD-46104] Add deploy_compliance command with dynamic commit fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ no pod is crash looping. A common source of error is that pods are stuck in `Ima
 due to Konflux referencing an image that doesn't exist yet. (The script tries to
 tackle this to some degree by requesting `latest` image tags and soon by checking if tags exist.)
 
+## Deploy Compliance
+
+Deploy the compliance service along with rbac (including debezium for replication). Both the compliance and rbac commit SHAs are resolved automatically from their respective GitHub repositories (`compliance-backend` and `insights-rbac`), but the compliance commit can optionally be overridden.
+
+```shell
+# Deploy compliance with the latest commits from both repos
+./deploy.sh compliance
+
+# Deploy compliance with a specific commit
+./deploy.sh compliance <full-compliance-commit-sha>
+```
+
+The command will:
+1. Fetch the latest commit from [compliance-backend](https://github.com/RedHatInsights/compliance-backend) (or use the provided one)
+2. Fetch the latest commit from [insights-rbac](https://github.com/RedHatInsights/insights-rbac)
+3. Deploy compliance with the resolved image tags and template refs
+4. Apply the SpiceDB schema
+5. Set up rbac debezium connectors
+
 ## Demo steps for HBI & rbac end-to-end flow with kessel from console
 
 These are the additional steps to get an end-to-end flow from the HBI 

--- a/deploy.sh
+++ b/deploy.sh
@@ -233,6 +233,40 @@ setup_kessel_inventory_consumer() {
   bonfire deploy kessel -C kessel-inventory-consumer -p kessel-relations/SPICEDB_QUANTIZATION_INTERVAL=2.5s -p kessel-relations/SPICEDB_QUANTIZATION_STALENESS_PERCENT=0
 }
 
+# parameters $1: compliance git commit (full SHA, optional - defaults to latest)
+deploy_compliance() {
+  echo "Deploying compliance..."
+
+  if [ -n "$1" ]; then
+    COMPLIANCE_COMMIT="$1"
+  else
+    COMPLIANCE_COMMIT=$(echo $(git ls-remote https://github.com/RedHatInsights/compliance-backend HEAD) | cut -d ' ' -f1)
+  fi
+  COMPLIANCE_SHORT_COMMIT="${COMPLIANCE_COMMIT:0:7}"
+
+  RBAC_GIT_COMMIT=$(echo $(git ls-remote https://github.com/RedHatInsights/insights-rbac HEAD) | cut -d ' ' -f1)
+  RBAC_SHORT_COMMIT="${RBAC_GIT_COMMIT:0:7}"
+
+  login
+  check_bonfire_namespace
+
+  bonfire deploy compliance --source=appsre \
+  --ref-env insights-production \
+  --set-image-tag quay.io/cloudservices/compliance-backend="${COMPLIANCE_SHORT_COMMIT}" \
+  --timeout 900 \
+  --optional-deps-method all \
+  --frontends false \
+  --set-template-ref compliance="${COMPLIANCE_COMMIT}" \
+  -p rbac/RBAC_KAFKA_CONSUMER_GROUP_ID=connect-relations-sink-connector \
+  -p rbac/REPLICATION_TO_RELATION_ENABLED=True \
+  --set-image-tag quay.io/redhat-services-prod/hcc-accessmanagement-tenant/insights-rbac="${RBAC_SHORT_COMMIT}" \
+  --set-template-ref rbac="${RBAC_GIT_COMMIT}"
+
+  apply_schema
+
+  setup_rbac_debezium
+}
+
 download_debezium_configuration() {
   RAW_BASE_URL="https://raw.githubusercontent.com/RedHatInsights/insights-rbac/master"
   FILES=(
@@ -436,6 +470,7 @@ usage() {
   echo "  deploy_unleash_importer_image      Deploy unleash importer"
   echo "  add_hosts_to_hbi [org_id] [count]  Add test hosts to HBI"
   echo "  add_users                          Add test users"
+  echo "  compliance [commit]                Deploy compliance with rbac debezium (default: latest commit)"
   echo "  host-replication-kafka             Set up host replication kafka connectors/consumers"
   echo "  apply-schema  [schema_file]        Applies the schema from the file in the arg, if no arg then the latest one from rbac-config"
   echo ""
@@ -496,6 +531,9 @@ case "$1" in
   host-replication-kafka)
     setup_kessel_inventory_consumer
     create_hbi_connectors
+    ;;
+  compliance)
+    deploy_compliance "$2"
     ;;
   apply-schema)
     apply_schema "$2"


### PR DESCRIPTION
## Summary
  - Add new `deploy_compliance` command that deploys the compliance service along with rbac (including
  debezium for replication)
  - Dynamically fetch latest commits from compliance-backend and insights-rbac via `git ls-remote`
  - Compliance commit can optionally be passed as argument to override the default (latest)
  - Add documentation for the `compliance` command in README

  ## Usage
  ```shell
  # Deploy with latest commits from both repos
  ./deploy.sh compliance

  # Deploy with a specific compliance commit
  ./deploy.sh compliance <full-compliance-commit-sha>

  Test plan

  - Run ./deploy.sh compliance without arguments — verify it fetches latest commits from both repos
  - Run ./deploy.sh compliance <specific-sha> — verify it uses the provided SHA for compliance
  - Verify rbac image tag and template ref use the dynamically fetched commit