### PR TITLE
[RHCLOUD-46106] Fix test user_id in rbac_users_data.json

### DIFF
--- a/data/rbac_users_data.json
+++ b/data/rbac_users_data.json
@@ -237,7 +237,7 @@
       }
     ],
     "attributes": {
-      "user_id": "12349",
+      "user_id": "912349",
       "account_id": "0369233",
       "account_number": "0369233",
       "entitlements": [


### PR DESCRIPTION
## Summary
- Change `user_id` from `12349` to `912349` to avoid collision with existing test users
- Add missing trailing newline to file
- This conflict with compliance IQE setup

## Test plan
- [ ] Run `./deploy.sh add_users` and verify the user is created with the correct `user_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)